### PR TITLE
Update index.html to work with Chromium 81+

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,7 +342,7 @@
 			} else if (mode != "auto") {
 				filters.push({vendorId: modes[mode].vendorId});
 			}
-			device = await navigator.hid.requestDevice({filters: filters});
+			device = (await navigator.hid.requestDevice({filters: filters}))[0];
 			if (!device) {
 				logappend('chooser dismissed without a selection');
 				return;


### PR DESCRIPTION
WebHID had a breaking change in Chromium 81: navigator.hid.requestDevice(FILTERS) now returns an array of devices (with one device in it) so we need to pick the first device in the array for this demo to keep working.